### PR TITLE
Feature/proxy di

### DIFF
--- a/packages/thirty/README.md
+++ b/packages/thirty/README.md
@@ -188,9 +188,9 @@ Each factory gets a reference to the created dependency container:
 export type AuthServiceDeps = { userService: UserService };
 export type AuthService = ReturnType<typeof authServiceFactory>;
 
-export const authServiceFactory = (deps: AuthServiceDeps) => ({
+export const authServiceFactory = ({userService}: AuthServiceDeps) => ({
   authenticate() {
-    const user = deps.userService.getUser();
+    const user = userService.getUser();
     // ...
   },
 });

--- a/packages/thirty/src/inject/index.spec.ts
+++ b/packages/thirty/src/inject/index.spec.ts
@@ -1,9 +1,9 @@
 import { compose, eventType } from '../core';
-import { inject, WithInject } from './index';
+import { inject, Injector } from './index';
 
 let handler;
 
-type Deps = {cService; aService: {a};} & WithInject;
+type Deps = {cService; aService: {a};} & Injector;
 
 const aService = jest.fn().mockImplementation(deps => ({ a: 'a', test: () => deps.bService.b }));
 const bService = jest.fn().mockImplementation(({cService, inject}: Deps) => ({ b: 'b', test: () => cService.c + inject('aService').a }));

--- a/packages/thirty/src/inject/index.ts
+++ b/packages/thirty/src/inject/index.ts
@@ -5,7 +5,7 @@ export type DepsFactories<T> = { [props: string]: (deps: T) => any };
 export type DepsOf<T extends DepsFactories<DepsOf<T>>> = {
   [P in keyof T]: ReturnType<T[P]>;
 };
-export interface WithInject {
+export interface Injector {
   inject: <K extends keyof this>(id: K) => this[K];
 }
 
@@ -41,4 +41,4 @@ export const createContainer = factories => {
   return container;
 };
 
-export const withInject = deps => ({...deps, inject: id => deps[id]})
+export const withInject = deps => ({...deps, inject: id => deps[id]});

--- a/packages/thirty/src/inject/index.ts
+++ b/packages/thirty/src/inject/index.ts
@@ -5,21 +5,40 @@ export type DepsFactories<T> = { [props: string]: (deps: T) => any };
 export type DepsOf<T extends DepsFactories<DepsOf<T>>> = {
   [P in keyof T]: ReturnType<T[P]>;
 };
+export interface WithInject {
+  inject: <K extends keyof this>(id: K) => this[K];
+}
 
 export const inject = <T extends object, D extends DepsFactories<DepsOf<D>>>(
   depsFactories: D,
 ): Middleware<T, Deps<DepsOf<D>> & T> => handler => {
-  let cachedDeps;
+  let container;
   return (event, ...args) => {
-    if (!cachedDeps) {
-      cachedDeps = resolveDepsFactories(depsFactories);
+    if (!container) {
+      container = createContainer(depsFactories);
     }
-    return handler(Object.assign(event, { deps: cachedDeps }, ...args));
+    return handler(Object.assign(event, { deps: container }, ...args));
   };
 };
 
-const resolveDepsFactories = factories =>
-  Object.keys(factories).reduce((deps, key) => {
-    deps[key] = factories[key](deps);
-    return deps;
-  }, {} as DepsOf<typeof factories>);
+export const createContainer = factories => {
+  const cache = {};
+  const circularDepIndicator = {};
+  const inject = id => container[id];
+  const container = new Proxy(factories, {
+    get(target, key) {
+      if(key === 'inject') return inject;
+      if (!cache[key]) {
+        if (circularDepIndicator[key]) {
+          throw new Error(`Circular dependency detected -> "${String(key)}"`);
+        }
+        circularDepIndicator[key] = true;
+        cache[key] = factories[key](container);
+      }
+      return cache[key];
+    }
+  });
+  return container;
+};
+
+export const withInject = deps => ({...deps, inject: id => deps[id]})


### PR DESCRIPTION
Allows destructuring of factory dependencies like so:

```ts
const userServiceFactory = ({authService}: UserServiceOptions) => ({
  loginUser() {
    authService.doLogin();
  }
});
```