### PR TITLE
properly type the createContainer method of the inject feature

### DIFF
--- a/packages/thirty/src/inject/index.ts
+++ b/packages/thirty/src/inject/index.ts
@@ -22,13 +22,13 @@ export const inject = <T extends object, D extends DepsFactories<DepsOf<D>>>(
   };
 };
 
-export const createContainer = factories => {
+export const createContainer = <D extends DepsFactories<DepsOf<D>>> (factories: D): DepsOf<D> => {
   const cache = {};
   const circularDepIndicator = {};
   const inject = id => container[id];
   let depChainKeys: string[] = [];
   const container = new Proxy(factories, {
-    get(target, key) {
+    get(target, key: string) {
       if (key === 'inject') return inject;
       if (!(key in cache) && (key in factories)) {
         depChainKeys.push(String(key));
@@ -43,7 +43,7 @@ export const createContainer = factories => {
       }
       return cache[key];
     },
-  });
+  }) as DepsOf<D>;
   return container;
 };
 


### PR DESCRIPTION
Adds typings to the createContainer method of the "inject" feature. 
This allows for using the dependency injection feature independently of the function composition which makes it more versatile.
This way a user can just use the createContainer method to wire up their dependencies without involving the Lambda event object.
